### PR TITLE
fix(HowToGuides): provide correct link for version release badge

### DIFF
--- a/Documentation/HowToGuides/Installation/README.md
+++ b/Documentation/HowToGuides/Installation/README.md
@@ -70,6 +70,6 @@ The package will now also show up in the Unity Package Manager UI. From then on 
 [Unity]: https://unity3d.com/
 [Unity Package Manager]: https://docs.unity3d.com/Manual/upm-ui.html
 [Project-Manifest]: https://docs.unity3d.com/Manual/upm-manifestPrj.html
-[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.Indicators.ObjectPointers.Unity.svg
+[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.Indicators.SpatialTargets.Unity.svg
 [Releases]: ../../../../../releases
 [Latest-Release]: ../../../../../releases/latest


### PR DESCRIPTION
The Version-Release badge link was incorrect and pointing to the
wrong repo. This has now been updated.