### PR TITLE
feat(SpatialTarget): add option to delay the auto deselect on activate

### DIFF
--- a/Documentation/API/SpatialTarget.md
+++ b/Documentation/API/SpatialTarget.md
@@ -19,6 +19,7 @@ A target in a spatial location that can react to given SurfaceData.
 * [Properties]
   * [ActivatingDispatcher]
   * [ApplySelectedTargetProperties]
+  * [DeactivateDelay]
   * [DeactivateOtherSpatialTargetsOnActivated]
   * [DeactivateSelfOnActivated]
   * [ExitAllHoveringOnActivated]
@@ -34,6 +35,7 @@ A target in a spatial location that can react to given SurfaceData.
   * [CreateHoverPayload(SurfaceData)]
   * [CreateSelectedPayload(SurfaceData)]
   * [Deselect(Boolean)]
+  * [DoDeselect()]
   * [DoDeselect(Boolean)]
   * [DoEnter(SurfaceData)]
   * [DoExit(SurfaceData)]
@@ -164,6 +166,16 @@ The Transform properties to apply the selected target overrides on.
 
 ```
 public TransformProperties ApplySelectedTargetProperties { get; set; }
+```
+
+#### DeactivateDelay
+
+The delay duration to wait before deactivating.
+
+##### Declaration
+
+```
+public float DeactivateDelay { get; set; }
 ```
 
 #### DeactivateOtherSpatialTargetsOnActivated
@@ -324,7 +336,7 @@ protected virtual SurfaceData CreateSelectedPayload(SurfaceData data)
 
 #### Deselect(Boolean)
 
-Deselects this [SpatialTarget] if it is in a selected state.
+De-selects this [SpatialTarget] if it is in a selected state.
 
 ##### Declaration
 
@@ -342,16 +354,26 @@ public virtual bool Deselect(bool keepInActivatingDispatcher = false)
 
 | Type | Description |
 | --- | --- |
-| System.Boolean | Whether the deselect was successful. |
+| System.Boolean | Whether the de-select was successful. |
 
-#### DoDeselect(Boolean)
+#### DoDeselect()
 
-Deselects this [SpatialTarget] if it is in a selected state.
+De-selects this [SpatialTarget] if it is in a selected state.
 
 ##### Declaration
 
 ```
-public virtual void DoDeselect(bool keepInActivatingDispatcher = false)
+public virtual void DoDeselect()
+```
+
+#### DoDeselect(Boolean)
+
+De-selects this [SpatialTarget] if it is in a selected state.
+
+##### Declaration
+
+```
+public virtual void DoDeselect(bool keepInActivatingDispatcher)
 ```
 
 ##### Parameters
@@ -563,6 +585,7 @@ public virtual bool Select(SpatialTargetDispatcher dispatcher, SurfaceData data)
 [Properties]: #Properties
 [ActivatingDispatcher]: #ActivatingDispatcher
 [ApplySelectedTargetProperties]: #ApplySelectedTargetProperties
+[DeactivateDelay]: #DeactivateDelay
 [DeactivateOtherSpatialTargetsOnActivated]: #DeactivateOtherSpatialTargetsOnActivated
 [DeactivateSelfOnActivated]: #DeactivateSelfOnActivated
 [ExitAllHoveringOnActivated]: #ExitAllHoveringOnActivated
@@ -578,6 +601,7 @@ public virtual bool Select(SpatialTargetDispatcher dispatcher, SurfaceData data)
 [CreateHoverPayload(SurfaceData)]: #CreateHoverPayloadSurfaceData
 [CreateSelectedPayload(SurfaceData)]: #CreateSelectedPayloadSurfaceData
 [Deselect(Boolean)]: #DeselectBoolean
+[DoDeselect()]: #DoDeselect
 [DoDeselect(Boolean)]: #DoDeselectBoolean
 [DoEnter(SurfaceData)]: #DoEnterSurfaceData
 [DoExit(SurfaceData)]: #DoExitSurfaceData

--- a/Documentation/API/SpatialTargetFacade.ActivationActions.md
+++ b/Documentation/API/SpatialTargetFacade.ActivationActions.md
@@ -27,8 +27,8 @@ public enum ActivationActions
 | Name | Description |
 | --- | --- |
 | ClearHoveringState | Clears any existing hover state on this target. |
-| DeselectOtherTargets | Deselects any other activated targets associated with the calling dispatcher. |
-| DeselectSelf | Deselects this target upon activating this target. |
+| DeselectOtherTargets | De-selects any other activated targets associated with the calling dispatcher. |
+| DeselectSelf | De-selects this target upon activating this target. |
 | DisableCollisionsOnActivate | Prevents the pointer from continuing to collide with the target when it is activated. |
 | HideActiveState | Hides the target active visual state. |
 

--- a/Documentation/API/SpatialTargetFacade.md
+++ b/Documentation/API/SpatialTargetFacade.md
@@ -18,6 +18,7 @@ The public interface into the SpatialTarget Prefab.
   * [ActionsOnActivate]
   * [ActionsOnHover]
   * [Configuration]
+  * [DeselectSelfDelay]
   * [IsEnabled]
   * [SourceValidity]
   * [UseSourcePointOverride]
@@ -26,6 +27,7 @@ The public interface into the SpatialTarget Prefab.
   * [Deselect(Boolean)]
   * [OnAfterActionOnHoverChange()]
   * [OnAfterActionOnSelectChange()]
+  * [OnAfterDeselectSelfDelayChange()]
   * [OnAfterIsEnabledChange()]
   * [OnAfterSourceValidityChange()]
   * [OnAfterUseSourcePointOverrideChange()]
@@ -142,6 +144,16 @@ The linked Internal Setup.
 public SpatialTargetConfigurator Configuration { get; protected set; }
 ```
 
+#### DeselectSelfDelay
+
+The amount of time to delay de-selecting this Spatial Target after it has been activated if the [ActionsOnActivate] [DeselectSelf] is enabled.
+
+##### Declaration
+
+```
+public float DeselectSelfDelay { get; set; }
+```
+
 #### IsEnabled
 
 Whether the [SpatialTargetFacade] is in the enabled state.
@@ -186,7 +198,7 @@ public bool UseTargetOverride { get; set; }
 
 #### Deselect(Boolean)
 
-Deselects the containing [SpatialTarget] if it is in a selected state.
+De-selects the containing [SpatialTarget] if it is in a selected state.
 
 ##### Declaration
 
@@ -218,6 +230,16 @@ Called after [ActionsOnActivate] has been changed.
 
 ```
 protected virtual void OnAfterActionOnSelectChange()
+```
+
+#### OnAfterDeselectSelfDelayChange()
+
+Called after [DeselectSelfDelay] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterDeselectSelfDelayChange()
 ```
 
 #### OnAfterIsEnabledChange()
@@ -265,10 +287,13 @@ protected virtual void OnAfterUseTargetOverrideChange()
 [SpatialTargetFacade.ActivationActions]: SpatialTargetFacade.ActivationActions.md
 [SpatialTargetFacade.HoverActions]: SpatialTargetFacade.HoverActions.md
 [SpatialTargetConfigurator]: SpatialTargetConfigurator.md
+[ActionsOnActivate]: SpatialTargetFacade.md#ActionsOnActivate
+[DeselectSelf]: SpatialTargetFacade.ActivationActions.md#ActivationActions_DeselectSelf
 [SpatialTargetFacade]: SpatialTargetFacade.md
 [SpatialTarget]: SpatialTarget.md
 [ActionsOnHover]: SpatialTargetFacade.md#ActionsOnHover
 [ActionsOnActivate]: SpatialTargetFacade.md#ActionsOnActivate
+[DeselectSelfDelay]: SpatialTargetFacade.md#DeselectSelfDelay
 [IsEnabled]: SpatialTargetFacade.md#IsEnabled
 [SourceValidity]: SpatialTargetFacade.md#SourceValidity
 [UseSourcePointOverride]: SpatialTargetFacade.md#UseSourcePointOverride
@@ -287,6 +312,7 @@ protected virtual void OnAfterUseTargetOverrideChange()
 [ActionsOnActivate]: #ActionsOnActivate
 [ActionsOnHover]: #ActionsOnHover
 [Configuration]: #Configuration
+[DeselectSelfDelay]: #DeselectSelfDelay
 [IsEnabled]: #IsEnabled
 [SourceValidity]: #SourceValidity
 [UseSourcePointOverride]: #UseSourcePointOverride
@@ -295,6 +321,7 @@ protected virtual void OnAfterUseTargetOverrideChange()
 [Deselect(Boolean)]: #DeselectBoolean
 [OnAfterActionOnHoverChange()]: #OnAfterActionOnHoverChange
 [OnAfterActionOnSelectChange()]: #OnAfterActionOnSelectChange
+[OnAfterDeselectSelfDelayChange()]: #OnAfterDeselectSelfDelayChange
 [OnAfterIsEnabledChange()]: #OnAfterIsEnabledChange
 [OnAfterSourceValidityChange()]: #OnAfterSourceValidityChange
 [OnAfterUseSourcePointOverrideChange()]: #OnAfterUseSourcePointOverrideChange

--- a/Runtime/SharedResources/Scripts/SpatialTarget.cs
+++ b/Runtime/SharedResources/Scripts/SpatialTarget.cs
@@ -45,6 +45,12 @@
         [field: DocumentedByXml]
         public bool DeactivateSelfOnActivated { get; set; } = true;
         /// <summary>
+        /// The delay duration to wait before deactivating.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public float DeactivateDelay { get; set; }
+        /// <summary>
         /// Deactivates any other <see cref="SpatialTarget"/> connected to the same <see cref="SpatialTargetDispatcher"/> when this <see cref="SpatialTarget"/> is activated.
         /// </summary>
         [Serialized]
@@ -288,7 +294,15 @@
 
             if (DeactivateSelfOnActivated)
             {
-                return Deselect();
+                if (DeactivateDelay.ApproxEquals(0f))
+                {
+                    return Deselect();
+                }
+                else
+                {
+                    Invoke("DoDeselect", DeactivateDelay);
+                    return true;
+                }
             }
 
             return true;
@@ -304,10 +318,10 @@
         }
 
         /// <summary>
-        /// Deselects this <see cref="SpatialTarget"/> if it is in a selected state.
+        /// De-selects this <see cref="SpatialTarget"/> if it is in a selected state.
         /// </summary>
         /// <param name="keepInActivatingDispatcher">Whether to keep this in the <see cref="ActivatingDispatcher.SelectedTargets"/> collection.</param>
-        /// <returns>Whether the deselect was successful.</returns>
+        /// <returns>Whether the de-select was successful.</returns>
         [RequiresBehaviourState]
         public virtual bool Deselect(bool keepInActivatingDispatcher = false)
         {
@@ -331,12 +345,20 @@
         }
 
         /// <summary>
-        /// Deselects this <see cref="SpatialTarget"/> if it is in a selected state.
+        /// De-selects this <see cref="SpatialTarget"/> if it is in a selected state.
         /// </summary>
         /// <param name="keepInActivatingDispatcher">Whether to keep this in the <see cref="ActivatingDispatcher.SelectedTargets"/> collection.</param>
-        public virtual void DoDeselect(bool keepInActivatingDispatcher = false)
+        public virtual void DoDeselect(bool keepInActivatingDispatcher)
         {
             Deselect(keepInActivatingDispatcher);
+        }
+
+        /// <summary>
+        /// De-selects this <see cref="SpatialTarget"/> if it is in a selected state.
+        /// </summary>
+        public virtual void DoDeselect()
+        {
+            Deselect(false);
         }
 
         /// <summary>

--- a/Runtime/SharedResources/Scripts/SpatialTargetConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/SpatialTargetConfigurator.cs
@@ -108,6 +108,7 @@
         {
             TargetController.ExitAllHoveringOnActivated = (Facade.ActionsOnActivate & SpatialTargetFacade.ActivationActions.ClearHoveringState) != 0;
             TargetController.DeactivateSelfOnActivated = (Facade.ActionsOnActivate & SpatialTargetFacade.ActivationActions.DeselectSelf) != 0;
+            TargetController.DeactivateDelay = Facade.DeselectSelfDelay;
             TargetController.DeactivateOtherSpatialTargetsOnActivated = (Facade.ActionsOnActivate & SpatialTargetFacade.ActivationActions.DeselectOtherTargets) != 0;
             ActiveStateContainer.SetActive((Facade.ActionsOnActivate & SpatialTargetFacade.ActivationActions.HideActiveState) == 0);
             CollisionLogicContainer.SetActive((Facade.ActionsOnActivate & SpatialTargetFacade.ActivationActions.DisableCollisionsOnActivate) != 0);

--- a/Runtime/SharedResources/Scripts/SpatialTargetFacade.cs
+++ b/Runtime/SharedResources/Scripts/SpatialTargetFacade.cs
@@ -43,11 +43,11 @@
             /// </summary>
             ClearHoveringState = 1 << 0,
             /// <summary>
-            /// Deselects this target upon activating this target.
+            /// De-selects this target upon activating this target.
             /// </summary>
             DeselectSelf = 1 << 1,
             /// <summary>
-            /// Deselects any other activated targets associated with the calling dispatcher.
+            /// De-selects any other activated targets associated with the calling dispatcher.
             /// </summary>
             DeselectOtherTargets = 1 << 2,
             /// <summary>
@@ -91,6 +91,12 @@
         [Serialized]
         [field: DocumentedByXml, UnityFlags]
         public ActivationActions ActionsOnActivate { get; set; } = (ActivationActions)(-1);
+        /// <summary>
+        /// The amount of time to delay de-selecting this Spatial Target after it has been activated if the <see cref="ActionsOnActivate"/> <see cref="ActivationActions.DeselectSelf"/> is enabled.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public float DeselectSelfDelay { get; set; }
         /// <summary>
         /// Determine which <see cref="SurfaceData"/> sources can interact with this <see cref="SpatialTargetFacade"/>.
         /// </summary>
@@ -142,7 +148,7 @@
         #endregion
 
         /// <summary>
-        /// Deselects the containing <see cref="SpatialTarget"/> if it is in a selected state.
+        /// De-selects the containing <see cref="SpatialTarget"/> if it is in a selected state.
         /// </summary>
         /// <param name="keepInActivatingDispatcher">Whether to keep this in the <see cref="ActivatingDispatcher.SelectedTargets"/> collection.</param>
         public virtual void Deselect(bool keepInActivatingDispatcher = false)
@@ -191,6 +197,15 @@
         /// </summary>
         [CalledAfterChangeOf(nameof(ActionsOnActivate))]
         protected virtual void OnAfterActionOnSelectChange()
+        {
+            Configuration.ConfigureActivationActions();
+        }
+
+        /// <summary>
+        /// Called after <see cref="DeselectSelfDelay"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(DeselectSelfDelay))]
+        protected virtual void OnAfterDeselectSelfDelayChange()
         {
             Configuration.ConfigureActivationActions();
         }


### PR DESCRIPTION
The DeselectSelf option can now be delayed by a given number of seconds
by providing a value to the DeselectSelfDelay property on the Spatial
Target Facade.