### PR TITLE
fix(prefabs): allow collision select after deselect occurs

### DIFF
--- a/Runtime/Prefabs/Indicators.SpatialTargets.Target.prefab
+++ b/Runtime/Prefabs/Indicators.SpatialTargets.Target.prefab
@@ -409,6 +409,17 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 7789618099214846136}
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
       - m_Target: {fileID: 127534091474685476}
         m_MethodName: InvokeDeactivated
         m_Mode: 1

--- a/Runtime/SharedResources/Scripts/SpatialTarget.cs
+++ b/Runtime/SharedResources/Scripts/SpatialTarget.cs
@@ -201,8 +201,7 @@
                 return false;
             }
 
-            SurfaceData surfaceData = new SurfaceData();
-            surfaceData.Transform = enteringObject.transform;
+            SurfaceData surfaceData = new SurfaceData(enteringObject.transform);
             return Enter(surfaceData);
         }
 
@@ -268,8 +267,7 @@
                 return false;
             }
 
-            SurfaceData surfaceData = new SurfaceData();
-            surfaceData.Transform = exitingObject.transform;
+            SurfaceData surfaceData = new SurfaceData(exitingObject.transform);
             return Exit(surfaceData);
         }
 
@@ -384,8 +382,7 @@
                 return false;
             }
 
-            SurfaceData surfaceData = new SurfaceData();
-            surfaceData.Transform = selectingObject.transform;
+            SurfaceData surfaceData = new SurfaceData(selectingObject.transform);
             return Select(surfaceData);
         }
 


### PR DESCRIPTION
There was an issue where the collision select would not be available
after the deselect was called because the select activation was only
happening on the LastExited event, meaning select can only happen
after everything stops hovering over it. But a deselect event should
also allow select to occur again.