### PR TITLE
chore(dependabot): remove bddckr from reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
     timezone: Europe/Berlin
   open-pull-requests-limit: 10
   reviewers:
-  - bddckr
   - thestonefox
   labels:
   - dependency-update


### PR DESCRIPTION
Chris hasn't been actively part of the project for a while.