### PR TITLE
feat(Dispatcher): allow dispatch operations to accept a GameObject

### DIFF
--- a/Documentation/API/Dispatcher.md
+++ b/Documentation/API/Dispatcher.md
@@ -11,11 +11,17 @@ The basis for all dispatcher types for the spatial targets.
   * [SourceValidity]
 * [Methods]
   * [ClearSourceValidity()]
+  * [DispatchEnter(GameObject)]
   * [DispatchEnter(SurfaceData)]
+  * [DispatchExit(GameObject)]
   * [DispatchExit(SurfaceData)]
+  * [DispatchSelect(GameObject)]
   * [DispatchSelect(SurfaceData)]
+  * [DoDispatchEnter(GameObject)]
   * [DoDispatchEnter(SurfaceData)]
+  * [DoDispatchExit(GameObject)]
   * [DoDispatchExit(SurfaceData)]
+  * [DoDispatchSelect(GameObject)]
   * [DoDispatchSelect(SurfaceData)]
   * [Enter(SurfaceData)]
   * [Exit(SurfaceData)]
@@ -65,6 +71,28 @@ Clears [SourceValidity].
 public virtual void ClearSourceValidity()
 ```
 
+#### DispatchEnter(GameObject)
+
+Dispatches the Enter command for the given data.
+
+##### Declaration
+
+```
+public virtual bool DispatchEnter(GameObject data)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | data | The data that has been entered. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether the dispatch was successful. |
+
 #### DispatchEnter(SurfaceData)
 
 Dispatches the Enter command for the given data.
@@ -80,6 +108,28 @@ public virtual bool DispatchEnter(SurfaceData data)
 | Type | Name | Description |
 | --- | --- | --- |
 | SurfaceData | data | The data that has been entered. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether the dispatch was successful. |
+
+#### DispatchExit(GameObject)
+
+Dispatches the Exit command for the given data.
+
+##### Declaration
+
+```
+public virtual bool DispatchExit(GameObject data)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | data | The data that has been exited. |
 
 ##### Returns
 
@@ -109,6 +159,28 @@ public virtual bool DispatchExit(SurfaceData data)
 | --- | --- |
 | System.Boolean | Whether the dispatch was successful. |
 
+#### DispatchSelect(GameObject)
+
+Dispatches the Select command for the given data.
+
+##### Declaration
+
+```
+public virtual bool DispatchSelect(GameObject data)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | data | The data that has been selected. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether the dispatch was successful. |
+
 #### DispatchSelect(SurfaceData)
 
 Dispatches the Select command for the given data.
@@ -131,6 +203,22 @@ public virtual bool DispatchSelect(SurfaceData data)
 | --- | --- |
 | System.Boolean | Whether the dispatch was successful. |
 
+#### DoDispatchEnter(GameObject)
+
+Dispatches the Enter command for the given data.
+
+##### Declaration
+
+```
+public virtual void DoDispatchEnter(GameObject data)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | data | The data that has been entered. |
+
 #### DoDispatchEnter(SurfaceData)
 
 Dispatches the Enter command for the given data.
@@ -147,6 +235,22 @@ public virtual void DoDispatchEnter(SurfaceData data)
 | --- | --- | --- |
 | SurfaceData | data | The data that has been entered. |
 
+#### DoDispatchExit(GameObject)
+
+Dispatches the Exit command for the given data.
+
+##### Declaration
+
+```
+public virtual void DoDispatchExit(GameObject data)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | data | The data that has been exited. |
+
 #### DoDispatchExit(SurfaceData)
 
 Dispatches the Exit command for the given data.
@@ -162,6 +266,22 @@ public virtual void DoDispatchExit(SurfaceData data)
 | Type | Name | Description |
 | --- | --- | --- |
 | SurfaceData | data | The data that has been exited. |
+
+#### DoDispatchSelect(GameObject)
+
+Dispatches the Select command for the given data.
+
+##### Declaration
+
+```
+public virtual void DoDispatchSelect(GameObject data)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | data | The data that has been selected. |
 
 #### DoDispatchSelect(SurfaceData)
 
@@ -280,11 +400,17 @@ protected abstract bool Select(SurfaceData data)
 [SourceValidity]: #SourceValidity
 [Methods]: #Methods
 [ClearSourceValidity()]: #ClearSourceValidity
+[DispatchEnter(GameObject)]: #DispatchEnterGameObject
 [DispatchEnter(SurfaceData)]: #DispatchEnterSurfaceData
+[DispatchExit(GameObject)]: #DispatchExitGameObject
 [DispatchExit(SurfaceData)]: #DispatchExitSurfaceData
+[DispatchSelect(GameObject)]: #DispatchSelectGameObject
 [DispatchSelect(SurfaceData)]: #DispatchSelectSurfaceData
+[DoDispatchEnter(GameObject)]: #DoDispatchEnterGameObject
 [DoDispatchEnter(SurfaceData)]: #DoDispatchEnterSurfaceData
+[DoDispatchExit(GameObject)]: #DoDispatchExitGameObject
 [DoDispatchExit(SurfaceData)]: #DoDispatchExitSurfaceData
+[DoDispatchSelect(GameObject)]: #DoDispatchSelectGameObject
 [DoDispatchSelect(SurfaceData)]: #DoDispatchSelectSurfaceData
 [Enter(SurfaceData)]: #EnterSurfaceData
 [Exit(SurfaceData)]: #ExitSurfaceData

--- a/Documentation/API/SpatialTargetDispatcher.md
+++ b/Documentation/API/SpatialTargetDispatcher.md
@@ -47,6 +47,18 @@ A Dispatcher that finds the appropriate [SpatialTarget] on the given data and di
 
 [Dispatcher.DoDispatchSelect(SurfaceData)]
 
+[Dispatcher.DispatchEnter(GameObject)]
+
+[Dispatcher.DoDispatchEnter(GameObject)]
+
+[Dispatcher.DispatchExit(GameObject)]
+
+[Dispatcher.DoDispatchExit(GameObject)]
+
+[Dispatcher.DispatchSelect(GameObject)]
+
+[Dispatcher.DoDispatchSelect(GameObject)]
+
 [Dispatcher.IsValidData(SurfaceData)]
 
 ##### Namespace
@@ -266,6 +278,12 @@ protected override bool Select(SurfaceData data)
 [Dispatcher.DoDispatchExit(SurfaceData)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DoDispatchExit_SurfaceData_
 [Dispatcher.DispatchSelect(SurfaceData)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DispatchSelect_SurfaceData_
 [Dispatcher.DoDispatchSelect(SurfaceData)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DoDispatchSelect_SurfaceData_
+[Dispatcher.DispatchEnter(GameObject)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DispatchEnter_GameObject_
+[Dispatcher.DoDispatchEnter(GameObject)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DoDispatchEnter_GameObject_
+[Dispatcher.DispatchExit(GameObject)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DispatchExit_GameObject_
+[Dispatcher.DoDispatchExit(GameObject)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DoDispatchExit_GameObject_
+[Dispatcher.DispatchSelect(GameObject)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DispatchSelect_GameObject_
+[Dispatcher.DoDispatchSelect(GameObject)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DoDispatchSelect_GameObject_
 [Dispatcher.IsValidData(SurfaceData)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_IsValidData_SurfaceData_
 [Tilia.Indicators.SpatialTargets]: README.md
 [TargetValidity]: SpatialTargetDispatcher.md#TargetValidity

--- a/Documentation/API/SpatialTargetDispatcherProcessor.md
+++ b/Documentation/API/SpatialTargetDispatcherProcessor.md
@@ -44,6 +44,18 @@ A [SpatialTargetDispatcher] collection that can be used to process multiple disp
 
 [Dispatcher.DoDispatchSelect(SurfaceData)]
 
+[Dispatcher.DispatchEnter(GameObject)]
+
+[Dispatcher.DoDispatchEnter(GameObject)]
+
+[Dispatcher.DispatchExit(GameObject)]
+
+[Dispatcher.DoDispatchExit(GameObject)]
+
+[Dispatcher.DispatchSelect(GameObject)]
+
+[Dispatcher.DoDispatchSelect(GameObject)]
+
 [Dispatcher.IsValidData(SurfaceData)]
 
 ##### Namespace
@@ -224,6 +236,12 @@ protected override bool Select(SurfaceData data)
 [Dispatcher.DoDispatchExit(SurfaceData)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DoDispatchExit_SurfaceData_
 [Dispatcher.DispatchSelect(SurfaceData)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DispatchSelect_SurfaceData_
 [Dispatcher.DoDispatchSelect(SurfaceData)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DoDispatchSelect_SurfaceData_
+[Dispatcher.DispatchEnter(GameObject)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DispatchEnter_GameObject_
+[Dispatcher.DoDispatchEnter(GameObject)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DoDispatchEnter_GameObject_
+[Dispatcher.DispatchExit(GameObject)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DispatchExit_GameObject_
+[Dispatcher.DoDispatchExit(GameObject)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DoDispatchExit_GameObject_
+[Dispatcher.DispatchSelect(GameObject)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DispatchSelect_GameObject_
+[Dispatcher.DoDispatchSelect(GameObject)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_DoDispatchSelect_GameObject_
 [Dispatcher.IsValidData(SurfaceData)]: Dispatcher.md#Tilia_Indicators_SpatialTargets_Dispatcher_IsValidData_SurfaceData_
 [Tilia.Indicators.SpatialTargets]: README.md
 [DispatcherObservableList]: Collection/DispatcherObservableList.md

--- a/Runtime/SharedResources/Scripts/Dispatcher.cs
+++ b/Runtime/SharedResources/Scripts/Dispatcher.cs
@@ -114,6 +114,81 @@
         }
 
         /// <summary>
+        /// Dispatches the Enter command for the given data.
+        /// </summary>
+        /// <param name="data">The data that has been entered.</param>
+        /// <returns>Whether the dispatch was successful.</returns>
+        public virtual bool DispatchEnter(GameObject data)
+        {
+            if (!this.IsValidState() || data == null)
+            {
+                return false;
+            }
+
+            SurfaceData surfaceData = new SurfaceData(data.transform);
+            return Enter(surfaceData);
+        }
+
+        /// <summary>
+        /// Dispatches the Enter command for the given data.
+        /// </summary>
+        /// <param name="data">The data that has been entered.</param>
+        public virtual void DoDispatchEnter(GameObject data)
+        {
+            DispatchEnter(data);
+        }
+
+        /// <summary>
+        /// Dispatches the Exit command for the given data.
+        /// </summary>
+        /// <param name="data">The data that has been exited.</param>
+        /// <returns>Whether the dispatch was successful.</returns>
+        public virtual bool DispatchExit(GameObject data)
+        {
+            if (!this.IsValidState() || data == null)
+            {
+                return false;
+            }
+
+            SurfaceData surfaceData = new SurfaceData(data.transform);
+            return Exit(surfaceData);
+        }
+
+        /// <summary>
+        /// Dispatches the Exit command for the given data.
+        /// </summary>
+        /// <param name="data">The data that has been exited.</param>
+        public virtual void DoDispatchExit(GameObject data)
+        {
+            DispatchExit(data);
+        }
+
+        /// <summary>
+        /// Dispatches the Select command for the given data.
+        /// </summary>
+        /// <param name="data">The data that has been selected.</param>
+        /// <returns>Whether the dispatch was successful.</returns>
+        public virtual bool DispatchSelect(GameObject data)
+        {
+            if (!this.IsValidState() || data == null)
+            {
+                return false;
+            }
+
+            SurfaceData surfaceData = new SurfaceData(data.transform);
+            return Select(surfaceData);
+        }
+
+        /// <summary>
+        /// Dispatches the Select command for the given data.
+        /// </summary>
+        /// <param name="data">The data that has been selected.</param>
+        public virtual void DoDispatchSelect(GameObject data)
+        {
+            DispatchSelect(data);
+        }
+
+        /// <summary>
         /// Processes the given data as an Enter command on a <see cref="SpatialTarget"/>.
         /// </summary>
         /// <param name="data">The data that has been entered.</param>

--- a/Runtime/SharedResources/Scripts/SpatialTargetDispatcher.cs
+++ b/Runtime/SharedResources/Scripts/SpatialTargetDispatcher.cs
@@ -137,12 +137,12 @@
         /// <returns>The found <see cref="SpatialTarget"/>.</returns>
         protected virtual SpatialTarget GetSpatialTarget(SurfaceData data)
         {
-            if (data == null || data.CollisionData.transform == null)
+            if (data == null || (data.CollisionData.transform == null && data.Transform == null))
             {
                 return null;
             }
 
-            SpatialTarget foundTarget = data.CollisionData.transform.gameObject.TryGetComponent<SpatialTarget>(false, true);
+            SpatialTarget foundTarget = (data.CollisionData.transform == null ? data.Transform : data.CollisionData.transform).gameObject.TryGetComponent<SpatialTarget>(false, true);
 
             if (foundTarget == null || !TargetValidity.Accepts(foundTarget.TargetContainer != null ? foundTarget.TargetContainer : foundTarget.gameObject))
             {


### PR DESCRIPTION
The Dispatch operations of Enter/Exit/Select now have methods where they can accept a GameObject as the target to dispatch to.